### PR TITLE
Fix "unclosed action" in footer partial

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -6,8 +6,7 @@
   <div
     class="footer-ccloud-shape"
   >
-    {{ with resources.Get "icons/ccloud_shape.svg" }}{{ ( . | minify
-    ).Content | safeHTML }}{{ end }}
+    {{ with resources.Get "icons/ccloud_shape.svg" }}{{ ( . | minify ).Content | safeHTML }}{{ end }}
   </div>
     
 </footer>


### PR DESCRIPTION
When running the instructions from the customer-docs README to localhost the documentation the build fails because of this bug.