### PR TITLE
chore(bpmn): set light bpmn background for fullscreen and added a comment because of viewer output

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,8 @@ Example:
 
 <img src="https://github.com/sapcc/hugo-documentation-templater/blob/main/static/images/ex_bpmn.png"  width="500">
 
+See further details on how to use BPMN diagrams in the [diagrams section](https://sapcc.github.io/hugo-documentation-templater/docs/markdown-helpers/#diagrams).
+
 ## Extra Information
 
 ### Bootstrap Version

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sapcc/hugo-documentation-templater/v3
 
-go 1.20
+go 1.24
 
 require (
 	github.com/FortAwesome/Font-Awesome v0.0.0-20240716171331-37eff7fa00de // indirect

--- a/internal/docs/markdown-helpers.md
+++ b/internal/docs/markdown-helpers.md
@@ -679,6 +679,16 @@ Example:
 
 `bpmn-js` is a library for rendering and interacting with BPMN 2.0 diagrams directly in the browser. Further details can be found at https://bpmn.io/toolkit/bpmn-js/ or the GitHub repository.
 
+**Note:**  
+When setting up a project with `hugo-documentation-templater`, if you still want to use the BPMN fullscreen viewer, make sure that the following configuration entry is **not overridden** in your `config.yaml`
+
+```yaml
+outputs:
+  home:
+    - HTML
+    - Viewer
+```
+
 ##### Inline
 
 Useful for small diagrams that can be included directly in the markdown file. The BPMN code should be enclosed in triple backticks with the `bpmn` language identifier.

--- a/layouts/index.viewer.html
+++ b/layouts/index.viewer.html
@@ -20,7 +20,7 @@
       }
     </style>
   </head>
-  <body class="theme-dark docs-layout">
+  <body class="docs-layout" data-bs-theme="light">
     <header>{{ partial "navbar.html" . }}</header>
 
     <!-- This piece of code (aside from the #canvas part) is used to respond to theme mode changes -->


### PR DESCRIPTION
## PR Description

Improved BPMN diagram in fullscreen mode, added clarification comments and upgraded Go version.

### Changes:
- Set a hardcoded light background for BPMN diagrams in fullscreen mode for better visibility.
- Added a comment explaining the BPMN viewer output behavior.
- Upgraded the Go version to **1.24** .