### PR TITLE
chore(workflow): set permissions to the jobs

### DIFF
--- a/.github/workflows/deploy-pr-preview.yaml
+++ b/.github/workflows/deploy-pr-preview.yaml
@@ -97,7 +97,7 @@ jobs:
     needs: [build-hugo-128, build-hugo-latest]
     runs-on: [ubuntu-latest]
     permissions:
-      contents: read
+      contents: write
       actions: write
     env:
       DEPLOY_PATH: tmp

--- a/.github/workflows/deploy-pr-preview.yaml
+++ b/.github/workflows/deploy-pr-preview.yaml
@@ -8,6 +8,10 @@ on:
       - synchronize
       - closed
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: write
+
 # Limit the concurrency of entire workflow
 concurrency: deploy-pr-preview-${{ github.ref }}
 
@@ -19,8 +23,6 @@ env:
 jobs:
   build-hugo-128:
     runs-on: [ubuntu-latest]
-    permissions:
-      contents: read
     if: github.event.action != 'closed'
     steps:
       - name: Checkout
@@ -57,8 +59,6 @@ jobs:
 
   build-hugo-latest:
     runs-on: [ubuntu-latest]
-    permissions:
-      contents: read
     if: github.event.action != 'closed'
     steps:
       - name: Checkout
@@ -96,9 +96,6 @@ jobs:
   deploy:
     needs: [build-hugo-128, build-hugo-latest]
     runs-on: [ubuntu-latest]
-    permissions:
-      contents: write
-      actions: write
     env:
       DEPLOY_PATH: tmp
     steps:

--- a/.github/workflows/deploy-pr-preview.yaml
+++ b/.github/workflows/deploy-pr-preview.yaml
@@ -18,8 +18,10 @@ env:
 
 jobs:
   build-hugo-128:
-    if: github.event.action != 'closed'
     runs-on: [ubuntu-latest]
+    permissions:
+      contents: read
+    if: github.event.action != 'closed'
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
@@ -55,6 +57,8 @@ jobs:
 
   build-hugo-latest:
     runs-on: [ubuntu-latest]
+    permissions:
+      contents: read
     if: github.event.action != 'closed'
     steps:
       - name: Checkout
@@ -92,6 +96,8 @@ jobs:
   deploy:
     needs: [build-hugo-128, build-hugo-latest]
     runs-on: [ubuntu-latest]
+    permissions:
+      contents: write
     env:
       DEPLOY_PATH: tmp
     steps:

--- a/.github/workflows/deploy-pr-preview.yaml
+++ b/.github/workflows/deploy-pr-preview.yaml
@@ -97,7 +97,8 @@ jobs:
     needs: [build-hugo-128, build-hugo-latest]
     runs-on: [ubuntu-latest]
     permissions:
-      contents: write
+      contents: read
+      actions: write
     env:
       DEPLOY_PATH: tmp
     steps:


### PR DESCRIPTION
## PR Description

This PR explicitly sets permissions for GitHub Actions jobs to avoid relying on default repository permissions.

## Changes made

- Pr preview workflow set permissions per job