### PR TITLE
chore(bpmn): fix unused variable

### DIFF
--- a/layouts/_default/_markup/render-codeblock-bpmn.html
+++ b/layouts/_default/_markup/render-codeblock-bpmn.html
@@ -18,7 +18,7 @@ $size "small") "400" (cond (eq $size "large") "800" "600") -}}
     try {
       await viewer.importXML(`{{ .Inner | safeJS }}`)
       const canvas = viewer.get("canvas")
-      const zoom = canvas.zoom("fit-viewport")
+      canvas.zoom("fit-viewport")
     } catch (err) {
       console.error("could not import BPMN 2.0 diagram", err)
     }


### PR DESCRIPTION
## Summary

Fixed unused variable warning in BPMN render template by removing unnecessary variable assignment.

## Changes

- Removed unused `zoom` variable in `layouts/_default/_markup/render-codeblock-bpmn.html`
- The `canvas.zoom("fit-viewport")` method is called for its side effect, so storing the return value is unnecessary

## Impact

- Resolves maintainability warning flagged by GitHub code scanning
- No functional changes - canvas zoom behavior remains the same