### PR TITLE
fix(ci): ensure PR preview cleanup runs on PR close

### DIFF
--- a/.github/workflows/deploy-pr-preview.yaml
+++ b/.github/workflows/deploy-pr-preview.yaml
@@ -97,38 +97,33 @@ jobs:
   deploy:
     needs: [build-hugo-128, build-hugo-latest]
     runs-on: [ubuntu-latest]
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
     env:
       DEPLOY_PATH: tmp
     steps:
       # needed so the working directory is recognized as a Git repository
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
         with:
           fetch-depth: 0
 
       - name: Create a folder with all compiled versions
-        if: github.event.action != 'closed'
         run: |
           mkdir -p ${{ env.DEPLOY_PATH }}
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        if: github.event.action != 'closed'
         with:
           name: hugo-custom
           path: ${{ env.DEPLOY_PATH }}/custom
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        if: github.event.action != 'closed'
         with:
           name: hugo-latest
           path: ${{ env.DEPLOY_PATH }}/latest
 
       - name: Generate index.html for Deployed Apps
-        if: github.event.action != 'closed'
         run: |
-          echo "<!DOCTYPE html><head><title>PR Preview</title></head><html><body><h1>Deployed Hugo Templater for PR ${GITHUB_HEAD_REF}</h1><ul>" > ${{ env.DEPLOY_PATH }}/index.html        
+          echo "<!DOCTYPE html><head><title>PR Preview</title></head><html><body><h1>Deployed Hugo Templater for PR ${GITHUB_HEAD_REF}</h1><ul>" > ${{ env.DEPLOY_PATH }}/index.html
           echo "<li><a href='./custom/index.html' target="_blank">Hugo ${HUGO_VERSION}</a></li>" >> ${{ env.DEPLOY_PATH }}/index.html
           echo "<li><a href='./latest/index.html' target="_blank">Hugo latest</a></li>" >> ${{ env.DEPLOY_PATH }}/index.html
           echo "</ul></body></html>" >> ${{ env.DEPLOY_PATH }}/index.html
@@ -140,3 +135,22 @@ jobs:
           umbrella-dir: pr-preview
           action: auto
           qr-code: false # don't need qr code for pr preview link
+
+  # Cleanup job runs independently when PR is closed (doesn't depend on build jobs)
+  cleanup:
+    runs-on: [ubuntu-latest]
+    if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Remove PR preview from gh-pages
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
+        with:
+          source-dir: ./
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: remove
+          qr-code: false

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Welcome to the Hugo Documentation Templater
+# Welcome to the Hugo Documentation Templater test
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Welcome to the Hugo Documentation Templater test
+# Welcome to the Hugo Documentation Templater
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 


### PR DESCRIPTION
## Problem
When a PR is closed, the preview deployment workflow wasn't cleaning up the preview directory from the `gh-pages` branch. This was because:

1. The `build-hugo-128` and `build-hugo-latest` jobs are skipped when `github.event.action == 'closed'`
2. The `deploy` job has `needs: [build-hugo-128, build-hugo-latest]`, so it's also skipped
3. The `rossjrw/pr-preview-action` with `action: auto` never runs on close
4. Result: PR preview directories accumulate in `gh-pages` and are never removed

## Solution
Split the workflow into two independent jobs:
- `deploy`: runs when PR is opened/updated (NOT closed) - builds and deploys preview
- `cleanup`: runs ONLY when PR is closed - removes the preview directory

The cleanup job doesn't depend on build jobs, so it runs successfully on PR close.

## Testing
- Close a PR and verify the preview directory is removed from `gh-pages`
- Open/update a PR and verify the preview still deploys correctly